### PR TITLE
Databricks: Bug - Resolve the parent folder path into an ID when creating an alert

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+- Fix a bug in 'create alert', where parent paths were not properly resolved [PAPP-34060]


### PR DESCRIPTION
Please ensure your pull request (PR) adheres to the following guidelines:

- Please refer to our contributing documentation for any questions on submitting a pull request, link: [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md)

## Pull Request Checklist

#### Please check if your PR fulfills the following requirements:
- [x] Testing of all the changes has been performed (for bug fixes / features)
- [x] The manual_readme_content.md has been reviewed and added / updated if needed (for bug fixes / features)
- [x] Use the following format for the PR description: `<App Name>: <PR Type> - <PR Description>`
- [x] Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.
- [x] Verify all checks are passing.
- [x] Do NOT use the `next` branch of the forked repo. Create separate feature branch for raising the PR.
- [x] Do NOT submit updates to dependencies unless it fixes an issue.
## Pull Request Type

#### Please check the type of change your PR introduces:
- [ ] New App
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation
- [ ] Other (please describe):

## Security Considerations (REQUIRED)
- [X] If you are exposing any endpoints using a [REST handler](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers),
  please document them in the `manual_readme_content.md`.
    - N/A
- [X] If this is a new connector or you are adding new actions
    - N/A
- [X] Are you introducing any new cryptography modules? If yes, please elaborate their purpose:
    - N/A
- [X] Are you are accessing the file system? If yes, please verify that you are only accessing paths returned through
the [Vault](https://docs.splunk.com/Documentation/SOARonprem/5.2.1/DevelopApps/AppDevAPIRef#Vault) API.
    - N/A
- [X] Are you are marking code to be ignored by Semgrep with [`nosemgrep`](https://semgrep.dev/docs/ignoring-files-folders-code/#ignoring-code-through-nosemgrep)?
    - N/A


## Release Notes (REQUIRED)
- When passing a `parent` directory to the `create alert` action, properly resolve the directory path into the directory ID expected by Databricks. Fixes PAPP-34060.

## What is the current behavior? (OPTIONAL)
- Passing a folder path (`folders/HOME/myfolder`) caused an internal server error from databricks.

## What is the new behavior? (OPTIONAL)
- Folder paths are properly resolved from `folders/HOME/myfolder` into a folder ID such as `folders/133329589`.

## Other information (OPTIONAL)
- Databricks issue: https://github.com/databricks/databricks-sdk-py/issues/650

---
Thanks for contributing!
